### PR TITLE
Trimming and doc comments

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -23,6 +23,7 @@ use registers::{Flag, R8, R16, Registers};
 
 pub const INTERRUPT_T_CYCLES: u8 = 5 * 4;
 
+/// I generated this data from 
 pub const UNPREFIXED_INSTRUCTION_T_CYCLE_TABLE: &[u8; 256] =
     include_bytes!("../../data/unprefixed_instruction_t_cycle_table.dat");
 pub const PREFIXED_INSTRUCTION_T_CYCLE_TABLE: &[u8; 256] =

--- a/src/cpu/registers.rs
+++ b/src/cpu/registers.rs
@@ -137,12 +137,12 @@ impl Registers {
             R16::HL => R8::H,
             R16::SP => {
                 self.sp &= 0x00FF;
-                self.sp |= ((byte as u16) << 8);
+                self.sp |= (byte as u16) << 8;
                 return;
             }
             R16::PC => {
                 self.pc &= 0x00FF;
-                self.pc |= ((byte as u16) << 8);
+                self.pc |= (byte as u16) << 8;
                 return;
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-#![allow(dead_code)]
-#![allow(unused)]
+// #![allow(dead_code)]
+// #![allow(unused)]
 
 mod cli;
 mod debugger;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,19 +12,18 @@ mod util;
 
 use cli::{Command, parse_cli_inputs};
 
-use cpu::{debug::print_t_cycle_tables, registers::R8, Cpu};
+use cpu::{registers::R8, Cpu};
 use debugger::run_debug;
 use mmu::{Mmu, memmap::*};
 use ppu::Ppu;
 use std::{
     cell::RefCell,
-    process,
     rc::Rc,
     time::{Duration, Instant},
 };
 use ui::UserInterface;
-
 use cpu::registers::R16;
+
 const SYSTEM_CLOCK_FREQUENCY: f64 = (1 << 22) as f64; // Hz
 const SYSTEM_CLOCK_PERIOD: f64 = 1.0 / SYSTEM_CLOCK_FREQUENCY; // Seconds
 
@@ -95,10 +94,11 @@ fn process_inputs(ui: &mut UserInterface, mmu: &Rc<RefCell<Mmu>>) {
     let n_button = ui.inputs_down.n;
 }
 
-// While you technically can obtain a copy of the original gameboy bootrom online,
-// it's legally dubious. It's safer and easier for the user if the emulator just
-// replicates the post-boot state, rather than requiring them to source the bootrom.
-// The pandocs contain good information about this (Section: 22. Power-Up Sequence)
+/// While you technically can obtain a copy of the original gameboy bootrom online,
+/// it's legally dubious. It's safer and easier for the user if the emulator just
+/// replicates the post-boot state, rather than requiring them to source the bootrom.
+/// [Pan Docs](https://gbdev.io/pandocs/Power_Up_Sequence.html?highlight=power%20up#power-up-sequence)
+/// contains all of the necessary information to do this.
 fn emulate_boot(mmu: &Rc<RefCell<Mmu>>, cpu: &mut Cpu) {
     cpu.reg.set(R8::A, 0x01);
     // The H and C flags in the F register depend on the cartridge header checksum.
@@ -115,40 +115,41 @@ fn emulate_boot(mmu: &Rc<RefCell<Mmu>>, cpu: &mut Cpu) {
     cpu.reg.set16(R16::SP, 0xFFFE);
 
     // Hardware registers
-    mmu.borrow_mut().write_byte_override(NR_10_ADDR, 0x80);
-    mmu.borrow_mut().write_byte_override(NR_11_ADDR, 0xBF);
-    mmu.borrow_mut().write_byte_override(NR_12_ADDR, 0xF3);
-    mmu.borrow_mut().write_byte_override(NR_13_ADDR, 0xFF);
-    mmu.borrow_mut().write_byte_override(NR_14_ADDR, 0xBF);
-    mmu.borrow_mut().write_byte_override(NR_21_ADDR, 0x3F);
-    mmu.borrow_mut().write_byte_override(NR_22_ADDR, 0x00);
-    mmu.borrow_mut().write_byte_override(NR_23_ADDR, 0xFF);
-    mmu.borrow_mut().write_byte_override(NR_24_ADDR, 0xBF);
-    mmu.borrow_mut().write_byte_override(NR_30_ADDR, 0x7F);
-    mmu.borrow_mut().write_byte_override(NR_31_ADDR, 0xFF);
-    mmu.borrow_mut().write_byte_override(NR_32_ADDR, 0x9F);
-    mmu.borrow_mut().write_byte_override(NR_33_ADDR, 0xFF);
-    mmu.borrow_mut().write_byte_override(NR_34_ADDR, 0xBF);
-    mmu.borrow_mut().write_byte_override(NR_41_ADDR, 0xFF);
-    mmu.borrow_mut().write_byte_override(NR_42_ADDR, 0x00);
-    mmu.borrow_mut().write_byte_override(NR_43_ADDR, 0x00);
-    mmu.borrow_mut().write_byte_override(NR_44_ADDR, 0xBF);
-    mmu.borrow_mut().write_byte_override(NR_50_ADDR, 0x77);
-    mmu.borrow_mut().write_byte_override(NR_51_ADDR, 0xF3);
-    mmu.borrow_mut().write_byte_override(NR_52_ADDR, 0xF1);
-    mmu.borrow_mut().write_byte_override(LCDC_ADDR, 0x91);
-    mmu.borrow_mut().write_byte_override(STAT_ADDR, 0x85);
-    mmu.borrow_mut().write_byte_override(SCY_ADDR, 0x00);
-    mmu.borrow_mut().write_byte_override(SCX_ADDR, 0x00);
-    mmu.borrow_mut().write_byte_override(LY_ADDR, 0x00);
-    mmu.borrow_mut().write_byte_override(LYC_ADDR, 0x00);
-    mmu.borrow_mut().write_byte_override(DMA_ADDR, 0xFF);
-    mmu.borrow_mut().write_byte_override(BGP_ADDR, 0xFC);
-    mmu.borrow_mut().write_byte_override(OBP0_ADDR, 0x00); // Uninitialized
-    mmu.borrow_mut().write_byte_override(OBP1_ADDR, 0x00); // Uninitialized
-    mmu.borrow_mut().write_byte_override(WY_ADDR, 0x00);
-    mmu.borrow_mut().write_byte_override(WX_ADDR, 0x00);
-    mmu.borrow_mut().write_byte_override(IE_ADDR, 0x00);
+    let mut mmu = mmu.borrow_mut();
+    mmu.write_byte_override(NR_10_ADDR, 0x80);
+    mmu.write_byte_override(NR_11_ADDR, 0xBF);
+    mmu.write_byte_override(NR_12_ADDR, 0xF3);
+    mmu.write_byte_override(NR_13_ADDR, 0xFF);
+    mmu.write_byte_override(NR_14_ADDR, 0xBF);
+    mmu.write_byte_override(NR_21_ADDR, 0x3F);
+    mmu.write_byte_override(NR_22_ADDR, 0x00);
+    mmu.write_byte_override(NR_23_ADDR, 0xFF);
+    mmu.write_byte_override(NR_24_ADDR, 0xBF);
+    mmu.write_byte_override(NR_30_ADDR, 0x7F);
+    mmu.write_byte_override(NR_31_ADDR, 0xFF);
+    mmu.write_byte_override(NR_32_ADDR, 0x9F);
+    mmu.write_byte_override(NR_33_ADDR, 0xFF);
+    mmu.write_byte_override(NR_34_ADDR, 0xBF);
+    mmu.write_byte_override(NR_41_ADDR, 0xFF);
+    mmu.write_byte_override(NR_42_ADDR, 0x00);
+    mmu.write_byte_override(NR_43_ADDR, 0x00);
+    mmu.write_byte_override(NR_44_ADDR, 0xBF);
+    mmu.write_byte_override(NR_50_ADDR, 0x77);
+    mmu.write_byte_override(NR_51_ADDR, 0xF3);
+    mmu.write_byte_override(NR_52_ADDR, 0xF1);
+    mmu.write_byte_override(LCDC_ADDR, 0x91);
+    mmu.write_byte_override(STAT_ADDR, 0x85);
+    mmu.write_byte_override(SCY_ADDR, 0x00);
+    mmu.write_byte_override(SCX_ADDR, 0x00);
+    mmu.write_byte_override(LY_ADDR, 0x00);
+    mmu.write_byte_override(LYC_ADDR, 0x00);
+    mmu.write_byte_override(DMA_ADDR, 0xFF);
+    mmu.write_byte_override(BGP_ADDR, 0xFC);
+    mmu.write_byte_override(OBP0_ADDR, 0x00); // Uninitialized
+    mmu.write_byte_override(OBP1_ADDR, 0x00); // Uninitialized
+    mmu.write_byte_override(WY_ADDR, 0x00);
+    mmu.write_byte_override(WX_ADDR, 0x00);
+    mmu.write_byte_override(IE_ADDR, 0x00);
 
 
 }

--- a/src/mmu/dma.rs
+++ b/src/mmu/dma.rs
@@ -1,4 +1,4 @@
-use crate::{constants::M_CYCLE_DURATION, mmu::memmap::OAM_START};
+use crate::constants::M_CYCLE_DURATION;
 
 use super::{
     Mmu,
@@ -17,7 +17,6 @@ const DMA_TARGET_START_ADDR: u16 = 0xFE00;
 pub struct Dma {
     timer: u16,
     pub active: bool,
-    pending: bool,
     source_start_addr: u16,
 }
 
@@ -26,7 +25,6 @@ impl Dma {
         Dma {
             timer: 0,
             active: false,
-            pending: false,
             source_start_addr: 0x0000,
         }
     }
@@ -36,9 +34,7 @@ impl Mmu {
     pub fn start_dma_transfer(&mut self, dma_byte: u8) {
         // The DMA register needs to be updated first
 
-        // println!("DMA START");
-        let (_, addr_mapped) = map_addr(DMA_ADDR);
-        let index = addr_mapped as usize;
+        let index = map_addr(DMA_ADDR);
         self.io[index] = dma_byte;
 
         self.dma.timer = DMA_TRANSFER_T_CYCLES + DMA_TRANSFER_T_DELAY;

--- a/src/mmu/memmap.rs
+++ b/src/mmu/memmap.rs
@@ -1,4 +1,4 @@
-//! For documentation on each of registers, check out the 
+//! For documentation on each of registers, check out the
 //! [Pandocs](https://gbdev.io/pandocs/Hardware_Reg_List.html?highlight=hardware%20registers#hardware-registers)
 
 use super::Mmu;
@@ -164,26 +164,41 @@ pub enum MemRegion {
     Ie,
 }
 
-// Return the memory region that the address is in, and an address
-//  offset by that region's start address.
-// The offset address can be used to directly indexing the array
-//  that represents that region of memory
-pub fn map_addr(addr: u16) -> (MemRegion, usize) {
-    use MemRegion as M;
-    let (region, start_addr) = match addr {
-        ROM_BANK_0_START..=ROM_BANK_0_END => (M::RomBank0, ROM_BANK_0_START),
-        ROM_BANK_1_START..=ROM_BANK_1_END => (M::RomBank1, ROM_BANK_1_START),
-        VRAM_START..=VRAM_END => (M::Vram, VRAM_START),
-        EXRAM_START..=EXRAM_END => (M::Exram, EXRAM_START),
-        WRAM_0_START..=WRAM_0_END => (M::Wram0, WRAM_0_START),
-        WRAM_1_START..=WRAM_1_END => (M::Wram1, WRAM_1_START),
-        ECHO_RAM_START..=ECHO_RAM_END => (M::EchoRam, ECHO_RAM_START),
-        OAM_START..=OAM_END => (M::Oam, OAM_START),
-        RESTRICTED_MEM_START..=RESTRICTED_MEM_END => (M::Restricted, RESTRICTED_MEM_START),
-        IO_START..=IO_END => (M::Io, IO_START),
-        HRAM_START..=HRAM_END => (M::Hram, HRAM_START),
-        IE_ADDR => (M::Ie, IE_ADDR),
+// Get an offset address relative to the start of that address's memory region
+pub fn map_addr(addr: u16) -> usize {
+    let start_addr = match addr {
+        ROM_BANK_0_START..=ROM_BANK_0_END => ROM_BANK_0_START,
+        ROM_BANK_1_START..=ROM_BANK_1_END => ROM_BANK_1_START,
+        VRAM_START..=VRAM_END => VRAM_START,
+        EXRAM_START..=EXRAM_END => EXRAM_START,
+        WRAM_0_START..=WRAM_0_END => WRAM_0_START,
+        WRAM_1_START..=WRAM_1_END => WRAM_1_START,
+        ECHO_RAM_START..=ECHO_RAM_END => ECHO_RAM_START,
+        OAM_START..=OAM_END => OAM_START,
+        RESTRICTED_MEM_START..=RESTRICTED_MEM_END =>  RESTRICTED_MEM_START,
+        IO_START..=IO_END => IO_START,
+        HRAM_START..=HRAM_END =>  HRAM_START,
+        IE_ADDR => IE_ADDR,
     };
 
-    (region, (addr - start_addr) as usize)
+    (addr - start_addr) as usize
+}
+
+/// Get the memory region of an address
+pub fn map_region(addr: u16) -> MemRegion {
+    use MemRegion as M;
+    match addr {
+        ROM_BANK_0_START..=ROM_BANK_0_END => M::RomBank0,
+        ROM_BANK_1_START..=ROM_BANK_1_END => M::RomBank1,
+        VRAM_START..=VRAM_END => M::Vram,
+        EXRAM_START..=EXRAM_END => M::Exram,
+        WRAM_0_START..=WRAM_0_END => M::Wram0,
+        WRAM_1_START..=WRAM_1_END => M::Wram1,
+        ECHO_RAM_START..=ECHO_RAM_END => M::EchoRam,
+        OAM_START..=OAM_END => M::Oam,
+        RESTRICTED_MEM_START..=RESTRICTED_MEM_END => M::Restricted,
+        IO_START..=IO_END => M::Io,
+        HRAM_START..=HRAM_END => M::Hram,
+        IE_ADDR => M::Ie,
+    }
 }

--- a/src/mmu/memmap.rs
+++ b/src/mmu/memmap.rs
@@ -1,3 +1,6 @@
+//! For documentation on each of registers, check out the 
+//! [Pandocs](https://gbdev.io/pandocs/Hardware_Reg_List.html?highlight=hardware%20registers#hardware-registers)
+
 use super::Mmu;
 
 // ----- Memory Regions -----
@@ -165,7 +168,7 @@ pub enum MemRegion {
 //  offset by that region's start address.
 // The offset address can be used to directly indexing the array
 //  that represents that region of memory
-pub fn map_addr(addr: u16) -> (MemRegion, u16) {
+pub fn map_addr(addr: u16) -> (MemRegion, usize) {
     use MemRegion as M;
     let (region, start_addr) = match addr {
         ROM_BANK_0_START..=ROM_BANK_0_END => (M::RomBank0, ROM_BANK_0_START),
@@ -182,5 +185,5 @@ pub fn map_addr(addr: u16) -> (MemRegion, u16) {
         IE_ADDR => (M::Ie, IE_ADDR),
     };
 
-    (region, addr - start_addr)
+    (region, (addr - start_addr) as usize)
 }

--- a/src/mmu/mod.rs
+++ b/src/mmu/mod.rs
@@ -1,3 +1,12 @@
+//! The MMU stores, controls, and regulates memory.
+//! The Gameboy has 64kB of memory, but it cannot be sufficiently represented
+//! by a single 64kB array. This is primarily due to the fact that the Gameboy supports
+//! ROM bank switching, which changes the part of the game's ROM that is visible in memory.
+//! 
+//! Different regions of memory are treated in different ways by different pieces of hardware on
+//! the Gameboy. For example, the CPU is restricted from accessing VRAM and OAM during certain
+//! timing windows. Certain registers, such as DIV and TIMA, incur side effects when written to.
+ 
 pub mod memmap;
 mod readwrite;
 mod dma;
@@ -30,7 +39,7 @@ pub struct Mmu {
 }
 
 impl Mmu {
-    //! I chose to use an Rc<RefCell<T>> for the MMU so that the CPU and PPU could borrow a mutable
+    //! I chose to use the Rc RefCell for the MMU so that the CPU and PPU could borrow a mutable
     //! reference to access it whenever they need to. It could just as easily be a global variable.
     pub fn new() -> Rc<RefCell<Mmu>> {
         let mmu = Mmu {
@@ -55,6 +64,7 @@ impl Mmu {
         Rc::new(RefCell::new(mmu))
     }
 
+    // todo! Support bigger ROMs
     pub fn load_rom(&mut self, path: &str) -> bool {
         let rom = match std::fs::read(path) {
             Ok(result) => result,

--- a/src/mmu/mod.rs
+++ b/src/mmu/mod.rs
@@ -1,9 +1,8 @@
-const TRANSFER_REQUESTED_VALUE: u8 = 0x81;
-const GARBAGE_VALUE: u8 = 0xFF;
-
-mod dma;
 pub mod memmap;
+mod readwrite;
+mod dma;
 mod timers;
+
 use dma::Dma;
 use memmap::*;
 use std::{cell::RefCell, rc::Rc};
@@ -31,6 +30,8 @@ pub struct Mmu {
 }
 
 impl Mmu {
+    //! I chose to use an Rc<RefCell<T>> for the MMU so that the CPU and PPU could borrow a mutable
+    //! reference to access it whenever they need to. It could just as easily be a global variable.
     pub fn new() -> Rc<RefCell<Mmu>> {
         let mmu = Mmu {
             dma: Dma::new(),
@@ -66,182 +67,7 @@ impl Mmu {
         true
     }
 
-    // Memory regions are all treated separately, and lots of regions and addresses
-    // have special rules that determine what happens when a read or write is done.
-    pub fn read_byte(&self, addr: u16) -> u8 {
-        let (mem_region, addr_mapped) = map_addr(addr);
-        let index = addr_mapped as usize;
-
-        use MemRegion as M;
-        match mem_region {
-            M::RomBank0 => self.rom_bank_00[index],
-            M::RomBank1 => self.rom_bank_01[index],
-            M::Vram => {
-                if self.vram_lock {
-                    GARBAGE_VALUE
-                } else {
-                    self.vram[index]
-                }
-            }
-            M::Exram => self.exram[index],
-            M::Wram0 => self.wram_0[index],
-            M::Wram1 => self.wram_1[index],
-            M::EchoRam => self.read_byte(addr - ECHO_OFFSET),
-            M::Oam => {
-                if self.oam_lock || self.dma.active {
-                    GARBAGE_VALUE
-                } else {
-                    self.oam[index]
-                }
-            }
-            M::Restricted => self.restricted_memory[index],
-            M::Io => match addr {
-                P1_ADDR => 0x0f,
-                IF_ADDR=> self.io[index] | 0b_1110_0000, // Upper 3 bits always read high
-                _ => self.io[index],
-            }
-            M::Hram => self.hram[index],
-            M::Ie => self.ie,
-        }
-    }
-
-    // Ignore all special rules
-    pub fn read_byte_override(&mut self, addr: u16) -> u8 {
-        let (mem_region, addr_mapped) = map_addr(addr);
-        let index = addr_mapped as usize;
-
-        use MemRegion as M;
-        match mem_region {
-            M::RomBank0 => self.rom_bank_00[index],
-            M::RomBank1 => self.rom_bank_01[index],
-            M::Vram => self.vram[index],
-            M::Exram => self.exram[index],
-            M::Wram0 => self.wram_0[index],
-            M::Wram1 => self.wram_1[index],
-            M::EchoRam => self.read_byte(addr - ECHO_OFFSET),
-            M::Oam => self.oam[index],
-            M::Restricted => self.restricted_memory[index],
-            M::Io => self.io[index],
-            M::Hram => self.hram[index],
-            M::Ie => self.ie,
-        }
-    }
-
-    // The PPU is not affected by the vram lock
-    pub fn bypass_read_byte_vram(&self, addr: u16) -> u8 {
-        let (mem_region, addr_mapped) = map_addr(addr);
-        if mem_region != MemRegion::Vram {
-            self.read_byte(addr)
-        } else {
-            let index = addr_mapped as usize;
-            self.vram[index]
-        }
-    }
-
-    pub fn write_byte(&mut self, addr: u16, byte: u8) {
-        let (mem_region, addr_mapped) = map_addr(addr);
-        let index = addr_mapped as usize;
-
-        if (addr == SC_ADDR) && (byte == TRANSFER_REQUESTED_VALUE) {
-            let c = self.read_byte(SB_ADDR) as char;
-            print!("{}", c);
-        }
-
-        use MemRegion as M;
-        match mem_region {
-            M::RomBank0 => self.rom_bank_00[index] = byte,
-            M::RomBank1 => self.rom_bank_01[index] = byte,
-            M::Vram => {
-                if !self.vram_lock {
-                    self.vram[index] = byte
-                }
-            }
-            M::Exram => self.exram[index] = byte,
-            M::Wram0 => self.wram_0[index] = byte,
-            M::Wram1 => self.wram_1[index] = byte,
-            M::EchoRam => self.write_byte(addr - ECHO_OFFSET, byte),
-            M::Oam => {
-                if !self.oam_lock && !self.dma.active {
-                    self.oam[index] = byte
-                }
-            }
-            M::Restricted => self.restricted_memory[index] = byte,
-            // IO writes have special behaviors
-            M::Io => match addr {
-                DIV_ADDR => self.write_byte_div(),
-                TMA_ADDR => self.write_byte_tma(byte),
-                TAC_ADDR => self.write_byte_tac(byte),
-                TIMA_ADDR => self.write_byte_tima(byte),
-                DMA_ADDR => self.start_dma_transfer(byte),
-                LY_ADDR => (),                                     // Read-only
-                STAT_ADDR => self.io[index] = byte & 0b_1111_1000, // Bottom 3 bits are read-only
-                IF_ADDR => self.io[index] = byte | 0b_1110_0000,   // Top 3 bits are always 1
-                _ => self.io[index] = byte,
-            },
-            M::Hram => self.hram[index] = byte,
-            M::Ie => self.ie = byte,
-        };
-    }
-
-    // During DMA, the CPU only has access to HRAM
-    fn dma_write() {}
-
-    // Ignore all special rules (except echo ram)
-    pub fn write_byte_override(&mut self, addr: u16, byte: u8) {
-        let (mem_region, addr_mapped) = map_addr(addr);
-        let index = addr_mapped as usize;
-
-        use MemRegion as M;
-        match mem_region {
-            M::RomBank0 => self.rom_bank_00[index] = byte,
-            M::RomBank1 => self.rom_bank_01[index] = byte,
-            M::Vram => self.vram[index] = byte,
-            M::Exram => self.exram[index] = byte,
-            M::Wram0 => self.wram_0[index] = byte,
-            M::Wram1 => self.wram_1[index] = byte,
-            M::EchoRam => self.write_byte(addr - ECHO_OFFSET, byte),
-            M::Oam => self.oam[index] = byte,
-            M::Restricted => self.restricted_memory[index] = byte,
-            M::Io => self.io[index] = byte,
-            M::Hram => self.hram[index] = byte,
-            M::Ie => self.ie = byte,
-        };
-    }
-
-    // LY is read-only by the CPU, but the PPU needs to write to them.
-    pub fn bypass_write_byte_ly(&mut self, byte: u8) {
-        let (_mem_region, addr_mapped) = map_addr(LY_ADDR);
-        let index = addr_mapped as usize;
-        self.io[index] = byte;
-    }
-
-    // The same is true for STAT, but only the bottom three bits.
-    pub fn bypass_write_byte_stat(&mut self, byte: u8) {
-        let (_mem_region, addr_mapped) = map_addr(STAT_ADDR);
-        let index = addr_mapped as usize;
-        self.io[index] = byte;
-    }
-
-    // Pay extra special attentian here to account for little-endianness
-    pub fn read_word(&self, addr: u16) -> u16 {
-        let lowbyte = self.read_byte(addr);
-        let highbyte = self.read_byte(addr + 1);
-        lowbyte as u16 | ((highbyte as u16) << 8)
-    }
-
-    pub fn write_word(&mut self, addr: u16, word: u16) {
-        let lowbyte = word as u8;
-        let highbyte = (word >> 8) as u8;
-        self.write_byte(addr, lowbyte);
-        self.write_byte(addr + 1, highbyte);
-    }
-
-    // An interrupt is requested by setting a specific bit in the IF register
-    pub fn request_interrupt(&mut self, interrupt_bit: u8) {
-        let mut byte = self.read_byte(IF_ADDR);
-        set_bit(&mut byte, interrupt_bit, true);
-        self.write_byte(IF_ADDR, byte);
-    }
+   
 }
 
 mod debug {

--- a/src/mmu/readwrite.rs
+++ b/src/mmu/readwrite.rs
@@ -5,8 +5,8 @@ const GARBAGE_VALUE: u8 = 0xFF;
 
 use super::*;
 impl Mmu {
-    //! Memory regions are all treated separately, and lots of regions and addresses
-    //! have special rules that determine what happens when a read or write is done.
+    /// Read a byte from memory. There are many side-effects and special cases that determine
+    /// how exactly the read is processed.
     pub fn read_byte(&self, addr: u16) -> u8 {
         let mem_region = map_region(addr);
         let index = map_addr(addr);
@@ -44,6 +44,8 @@ impl Mmu {
         }
     }
 
+    /// Write a byte to memory. There are many side-effects and special cases that determine
+    /// how exactly the read is processed.
     pub fn write_byte(&mut self, addr: u16, byte: u8) {
         let mem_region= map_region(addr);
         let index = map_addr(addr);
@@ -89,8 +91,8 @@ impl Mmu {
         };
     }
 
-    /// This function bypasses all of the special conditions and side-effects of the 
-    /// standard read_byte function. Use this carefully!
+    /// Read one byte from memory, bypassing all of the special cases
+    /// and side-effects of the standard read_byte function. Use this with caution!
     pub fn read_byte_override(&self, addr: u16) -> u8 {
         let mem_region= map_region(addr);
         let index = map_addr(addr);
@@ -114,8 +116,8 @@ impl Mmu {
 
    
 
-    /// This function bypasses all of the special conditions and side-effects of the 
-    /// standard write_byte function. Use this carefully!
+    /// Write one byte from memory, bypassing all of the special cases
+    /// and side-effects of the standard read_byte function. Use this with caution!
     pub fn write_byte_override(&mut self, addr: u16, byte: u8) {
         let index = map_addr(addr);
         let region = map_region(addr);

--- a/src/mmu/readwrite.rs
+++ b/src/mmu/readwrite.rs
@@ -1,0 +1,184 @@
+// ! This value is written to 
+const TRANSFER_REQUESTED_VALUE: u8 = 0x81;
+// ! Attempts to access an unavailable region of memory typically retusn all high bits
+const GARBAGE_VALUE: u8 = 0xFF;
+
+use super::*;
+impl Mmu {
+    //! Memory regions are all treated separately, and lots of regions and addresses
+    //! have special rules that determine what happens when a read or write is done.
+    pub fn read_byte(&self, addr: u16) -> u8 {
+        let (mem_region, index) = map_addr(addr);
+
+        use MemRegion as M;
+        match mem_region {
+            M::RomBank0 => self.rom_bank_00[index],
+            M::RomBank1 => self.rom_bank_01[index],
+            M::Vram => {
+                if self.vram_lock {
+                    GARBAGE_VALUE
+                } else {
+                    self.vram[index]
+                }
+            }
+            M::Exram => self.exram[index],
+            M::Wram0 => self.wram_0[index],
+            M::Wram1 => self.wram_1[index],
+            M::EchoRam => self.read_byte(addr - ECHO_OFFSET),
+            M::Oam => {
+                if self.oam_lock || self.dma.active {
+                    GARBAGE_VALUE
+                } else {
+                    self.oam[index]
+                }
+            }
+            M::Restricted => self.restricted_memory[index],
+            M::Io => match addr {
+                P1_ADDR => 0x0f,
+                IF_ADDR => self.io[index] | 0b_1110_0000, // Upper 3 bits always read high
+                _ => self.io[index],
+            },
+            M::Hram => self.hram[index],
+            M::Ie => self.ie,
+        }
+    }
+
+    pub fn write_byte(&mut self, addr: u16, byte: u8) {
+        let (mem_region, addr_mapped) = map_addr(addr);
+        let index = addr_mapped as usize;
+
+        if (addr == SC_ADDR) && (byte == TRANSFER_REQUESTED_VALUE) {
+            let c = self.read_byte(SB_ADDR) as char;
+            print!("{}", c);
+        }
+
+        use MemRegion as M;
+        match mem_region {
+            M::RomBank0 => self.rom_bank_00[index] = byte,
+            M::RomBank1 => self.rom_bank_01[index] = byte,
+            M::Vram => {
+                if !self.vram_lock {
+                    self.vram[index] = byte
+                }
+            }
+            M::Exram => self.exram[index] = byte,
+            M::Wram0 => self.wram_0[index] = byte,
+            M::Wram1 => self.wram_1[index] = byte,
+            M::EchoRam => self.write_byte(addr - ECHO_OFFSET, byte),
+            M::Oam => {
+                if !self.oam_lock && !self.dma.active {
+                    self.oam[index] = byte
+                }
+            }
+            M::Restricted => self.restricted_memory[index] = byte,
+            // IO writes have special behaviors
+            M::Io => match addr {
+                DIV_ADDR => self.write_byte_div(),
+                TMA_ADDR => self.write_byte_tma(byte),
+                TAC_ADDR => self.write_byte_tac(byte),
+                TIMA_ADDR => self.write_byte_tima(byte),
+                DMA_ADDR => self.start_dma_transfer(byte),
+                LY_ADDR => (),                                     // Read-only
+                STAT_ADDR => self.io[index] = byte & 0b_1111_1000, // Bottom 3 bits are read-only
+                IF_ADDR => self.io[index] = byte | 0b_1110_0000,   // Top 3 bits are always 1
+                _ => self.io[index] = byte,
+            },
+            M::Hram => self.hram[index] = byte,
+            M::Ie => self.ie = byte,
+        };
+    }
+
+    // ! This function bypasses all of the special conditions and side-effects of the 
+    // ! standard read_byte function. Use this carefully!
+    pub fn read_byte_override(&mut self, addr: u16) -> u8 {
+        let (mem_region, addr_mapped) = map_addr(addr);
+        let index = addr_mapped as usize;
+
+        use MemRegion as M;
+        match mem_region {
+            M::RomBank0 => self.rom_bank_00[index],
+            M::RomBank1 => self.rom_bank_01[index],
+            M::Vram => self.vram[index],
+            M::Exram => self.exram[index],
+            M::Wram0 => self.wram_0[index],
+            M::Wram1 => self.wram_1[index],
+            M::EchoRam => self.read_byte(addr - ECHO_OFFSET),
+            M::Oam => self.oam[index],
+            M::Restricted => self.restricted_memory[index],
+            M::Io => self.io[index],
+            M::Hram => self.hram[index],
+            M::Ie => self.ie,
+        }
+    }
+
+    // The PPU is not affected by the vram lock
+    pub fn bypass_read_byte_vram(&self, addr: u16) -> u8 {
+        let (mem_region, addr_mapped) = map_addr(addr);
+        if mem_region != MemRegion::Vram {
+            self.read_byte(addr)
+        } else {
+            let index = addr_mapped as usize;
+            self.vram[index]
+        }
+    }
+
+    /// This function bypasses all of the special conditions and side-effects of the 
+    /// standard write_byte function. Use this carefully!
+    pub fn write_byte_override(&mut self, addr: u16, byte: u8) {
+        let (mem_region, addr_mapped) = map_addr(addr);
+        let index = addr_mapped as usize;
+
+        use MemRegion as M;
+        match mem_region {
+            M::RomBank0 => self.rom_bank_00[index] = byte,
+            M::RomBank1 => self.rom_bank_01[index] = byte,
+            M::Vram => self.vram[index] = byte,
+            M::Exram => self.exram[index] = byte,
+            M::Wram0 => self.wram_0[index] = byte,
+            M::Wram1 => self.wram_1[index] = byte,
+            M::EchoRam => self.write_byte(addr - ECHO_OFFSET, byte),
+            M::Oam => self.oam[index] = byte,
+            M::Restricted => self.restricted_memory[index] = byte,
+            M::Io => self.io[index] = byte,
+            M::Hram => self.hram[index] = byte,
+            M::Ie => self.ie = byte,
+        };
+    }
+
+    // LY is read-only by the CPU, but the PPU needs to write to them.
+    pub fn bypass_write_byte_ly(&mut self, byte: u8) {
+        let (_mem_region, addr_mapped) = map_addr(LY_ADDR);
+        let index = addr_mapped as usize;
+        self.io[index] = byte;
+    }
+
+    // The same is true for STAT, but only the bottom three bits
+    pub fn bypass_write_byte_stat(&mut self, byte: u8) {
+        let (_mem_region, addr_mapped) = map_addr(STAT_ADDR);
+        let index = addr_mapped as usize;
+        self.io[index] = byte;
+    }
+
+    /// Read a two-byte value to memory, in little-endian order
+    pub fn read_word(&self, addr: u16) -> u16 {
+        let lowbyte = self.read_byte(addr);
+        let highbyte = self.read_byte(addr + 1);
+        lowbyte as u16 | ((highbyte as u16) << 8)
+    }
+
+    /// Write a two-byte value to memory, in little-endian order
+    pub fn write_word(&mut self, addr: u16, word: u16) {
+        let lowbyte = word as u8;
+        let highbyte = (word >> 8) as u8;
+        self.write_byte(addr, lowbyte);
+        self.write_byte(addr + 1, highbyte);
+    }
+
+    /// An interrupt is requested by setting a specific bit in the IF register
+    pub fn request_interrupt(&mut self, interrupt_bit: u8) {
+        let mut byte = self.read_byte(IF_ADDR);
+        set_bit(&mut byte, interrupt_bit, true);
+        self.write_byte(IF_ADDR, byte);
+    }
+
+}

--- a/src/mmu/timers.rs
+++ b/src/mmu/timers.rs
@@ -3,7 +3,7 @@
 
 //! TIMA increments when its corresponding bit in the system clock flips from 1 to 0.
 //! The corresponding bit is dictated by the lower two bits of TAC, which are mapped as follows.
-//! More information can be found at https://gbdev.io/pandocs/Timer_Obscure_Behaviour.html
+//! More information available on [Pan Docs](https://gbdev.io/pandocs/Timer_Obscure_Behaviour.html)
 
 use super::*;
 use crate::{

--- a/src/ppu/mod.rs
+++ b/src/ppu/mod.rs
@@ -66,7 +66,7 @@ impl Ppu {
         }
     }
 
-    /// This function progresses the state of the PPU by one t-cycle
+    /// This function progresses the state of the PPU by one t-cycle.
     pub fn tick(&mut self) {
         let ppu_mode = self.get_mode();
         let ppu_enabled = self.get_lcdc_flag(LCD_AND_PPU_ENABLE_BIT);


### PR DESCRIPTION
I had a lot of redundant memory read/write functions, so I trimmed those away. I also changed a lot of comments in the MMU to doc comments, and also made them more thorough.